### PR TITLE
Add BatchPayment object to BankTransaction and Payment e/p

### DIFF
--- a/examples/banktransactions/json.yml
+++ b/examples/banktransactions/json.yml
@@ -31,6 +31,18 @@ response-get-single: |
         "Code": "090",
         "Name": "Business Bank Account"
       },
+      "BatchPayment": {
+        "Account": {
+          "AccountID": "ac993f75-035b-433c-82e0-7b7a2d40802c"
+        },
+        "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+        "Date": "\/Date(1401062400000+0000)\/",
+        "Type": "RECBATCH",
+        "Status": "AUTHORISED",
+        "TotalAmount": "100.00",
+        "UpdatedDateUTC": "\/Date(1439434356790+0000)\/",
+        "IsReconciled": "true"
+      },
       "Type": "SPEND",
       "Reference": "Sub 098801",
       "IsReconciled": "true"

--- a/examples/banktransactions/xml.yml
+++ b/examples/banktransactions/xml.yml
@@ -33,6 +33,18 @@ response-get-single: |
           <Code>090</Code>
           <Name>Business Bank Account</Name>
         </BankAccount>
+        <BatchPayment>
+          <Account>
+            <AccountID>ac993f75-035b-433c-82e0-7b7a2d40802c</AccountID>
+          </Account>
+          <BatchPaymentID>b54aa50c-794c-461b-89d1-846e1b84d9c0</BatchPaymentID>
+          <Date>2017-02-25T00:00:00</Date>
+          <Type>RECBATCH</Type>
+          <Status>AUTHORISED</Status>
+          <TotalAmount>100.00</TotalAmount>
+          <UpdatedDateUTC>2017-02-25T12:19:56.657</UpdatedDateUTC>
+          <IsReconciled>true</IsReconciled>
+        </BatchPayment>
         <Type>SPEND</Type>
         <Reference>Sub 098801</Reference>
         <IsReconciled>true</IsReconciled>

--- a/examples/payments/json.yml
+++ b/examples/payments/json.yml
@@ -4,6 +4,19 @@ response-get-single: |
     "Payments": [
       {
         "PaymentID": "b26fd49a-cbae-470a-a8f8-bcbc119e0379",
+        "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+        "BatchPayment": {
+          "Account": {
+            "AccountID": "ac993f75-035b-433c-82e0-7b7a2d40802c"
+          },
+          "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+          "Date": "\/Date(1455667200000+0000)\/",
+          "Type": "RECBATCH",
+          "Status": "AUTHORISED",
+          "TotalAmount": "600.00",
+          "UpdatedDateUTC": "\/Date(1289572582537+0000)\/",
+          "IsReconciled": "true"
+        },
         "Date": "\/Date(1455667200000+0000)\/",
         "BankAmount": 500.00,
         "Amount": 500.00,

--- a/examples/payments/xml.yml
+++ b/examples/payments/xml.yml
@@ -4,6 +4,19 @@ response-get-single: |
     <Payments>
       <Payment>
         <PaymentID>b26fd49a-cbae-470a-a8f8-bcbc119e0379</PaymentID>
+        <BatchPaymentID>b5ef98d8-bf5c-473e-8f84-c66c6bdcb516</BatchPaymentID>
+        <BatchPayment>
+          <Account>
+              <AccountID>ac993f75-035b-433c-82e0-7b7a2d40802c</AccountID>
+          </Account>
+          <BatchPaymentID>b5ef98d8-bf5c-473e-8f84-c66c6bdcb516</BatchPaymentID>
+          <Date>2016-02-17T00:00:00</Date>
+          <Type>RECBATCH</Type>
+          <Status>AUTHORISED</Status>
+          <TotalAmount>100.00</TotalAmount>
+          <UpdatedDateUTC>2010-11-12T14:36:22.537</UpdatedDateUTC>
+          <IsReconciled>true</IsReconciled>
+        </BatchPayment>
         <Date>2016-02-17T00:00:00</Date>
         <BankAmount>500.00</BankAmount>
         <Amount>500.00</Amount>


### PR DESCRIPTION
With our latest release, we have added a new object 'BatchPayment' to the payment and bank transaction endpoint. 
This is returned only when the payment/bank transaction is part of a batch. 
It will be returned for both fetch by search and fetch by ID.