### PR TITLE
Syntax fix

### DIFF
--- a/examples/manual-journals/json.yml
+++ b/examples/manual-journals/json.yml
@@ -83,24 +83,24 @@ request-add-draft-detailed: |
           "LineAmount": -1000.00,
           "AccountCode": "489",
           "TaxType": "NONE",
-          "Tracking": {
-            "TrackingCategory": {
-              "Name": "Region",
-              "Option": "South"
-            }
-          }
+          "Tracking": [
+              {
+                "Name": "Region",
+                "Option": "South"
+              }
+          ]
         },
         {
           "Description": "Prepayment",
           "LineAmount": 1000.00,
           "AccountCode": "620",
           "TaxType": "NONE",
-          "Tracking": {
-            "TrackingCategory": {
+          "Tracking": [
+            {
               "Name": "Region",
-              "Option": "North"
+              "Option": "South"
             }
-          }
+          ]
         }
       ]
     },

--- a/examples/manual-journals/json.yml
+++ b/examples/manual-journals/json.yml
@@ -84,10 +84,10 @@ request-add-draft-detailed: |
           "AccountCode": "489",
           "TaxType": "NONE",
           "Tracking": [
-              {
-                "Name": "Region",
-                "Option": "South"
-              }
+            {
+              "Name": "Region",
+              "Option": "South"
+            }
           ]
         },
         {


### PR DESCRIPTION
Fixes Syntax for how to add tracking categories on a journal line when posting a manual journal.

For more reference [internal-link](https://trello.com/c/l9cJV5io/544-post-manualjournal-tracking-category-bug)